### PR TITLE
Fix up Python 3.11 breakages

### DIFF
--- a/src/contracts/backported.py
+++ b/src/contracts/backported.py
@@ -1,5 +1,4 @@
 import sys
-from inspect import ArgSpec
 
 import six
 
@@ -12,6 +11,7 @@ else:  # pragma: no cover
     FullArgSpec = namedtuple('FullArgSpec', 'args varargs varkw defaults'
                              ' kwonlyargs kwonlydefaults annotations')
     from inspect import getargspec as _getargspec
+    from inspect import ArgSpec
 
     def getargspec(function):
         # print 'hasattr im_func', hasattr(function, 'im_func')
@@ -150,6 +150,3 @@ else:  # pragma: no cover
                 f_name, 'at least' if defaults else 'exactly', num_required,
                 'arguments' if num_required > 1 else 'argument', num_total))
         return arg2value
-
-
-

--- a/src/contracts/library/map.py
+++ b/src/contracts/library/map.py
@@ -13,7 +13,7 @@ class Map(Contract):
         self.value_c = value_c
 
     def check_contract(self, context, value, silent):
-        if not isinstance(value, collections.Mapping):
+        if not isinstance(value, collections.abc.Mapping):
             error = 'Expected a Mapping, got %r.' % value.__class__.__name__
             raise ContractNotRespected(contract=self, error=error,
                                        value=value, context=context)

--- a/src/contracts/library/miscellaneous_aliases.py
+++ b/src/contracts/library/miscellaneous_aliases.py
@@ -14,32 +14,32 @@ def m_new_contract(name, f):
     from contracts.library.extensions import CheckCallable
     from contracts.library.extensions import Extension
     Extension.registrar[name] = CheckCallable(f)
-    
 
-m_new_contract('Container', ist(collections.Container))
+
+m_new_contract('Container', ist(collections.abc.Container))
 # todo: Iterable(x)
-m_new_contract('Iterable', ist(collections.Iterable))
+m_new_contract('Iterable', ist(collections.abc.Iterable))
 
-m_new_contract('Hashable', ist(collections.Hashable))
+m_new_contract('Hashable', ist(collections.abc.Hashable))
 
 
 
-m_new_contract('Iterator', ist(collections.Iterator))
-m_new_contract('Sized', ist(collections.Sized))
-m_new_contract('Callable', ist(collections.Callable))
-m_new_contract('Sequence', ist(collections.Sequence))
-m_new_contract('Set', ist(collections.Set))
-m_new_contract('MutableSequence', ist(collections.MutableSequence))
-m_new_contract('MutableSet', ist(collections.MutableSet))
-m_new_contract('Mapping', ist(collections.Mapping))
-m_new_contract('MutableMapping', ist(collections.MutableMapping))
+m_new_contract('Iterator', ist(collections.abc.Iterator))
+m_new_contract('Sized', ist(collections.abc.Sized))
+m_new_contract('Callable', ist(collections.abc.Callable))
+m_new_contract('Sequence', ist(collections.abc.Sequence))
+m_new_contract('Set', ist(collections.abc.Set))
+m_new_contract('MutableSequence', ist(collections.abc.MutableSequence))
+m_new_contract('MutableSet', ist(collections.abc.MutableSet))
+m_new_contract('Mapping', ist(collections.abc.Mapping))
+m_new_contract('MutableMapping', ist(collections.abc.MutableMapping))
 #new_contract('MappingView', ist(collections.MappingView))
 #new_contract('ItemsView', ist(collections.ItemsView))
 #new_contract('ValuesView', ist(collections.ValuesView))
 
 
 # Not a lambda to have better messages
-def is_None(x): 
+def is_None(x):
     return x is None
 
 m_new_contract('None', is_None)

--- a/src/contracts/library/seq.py
+++ b/src/contracts/library/seq.py
@@ -38,7 +38,7 @@ class Seq(Contract):
 
             return
 
-        if not isinstance(value, collections.Sequence):
+        if not isinstance(value, collections.abc.Sequence):
             error = 'Expected a Sequence, got %r.' % value.__class__.__name__
             raise ContractNotRespected(self, error, value, context)
 

--- a/src/contracts/library/sets.py
+++ b/src/contracts/library/sets.py
@@ -13,7 +13,7 @@ class ASet(Contract):
         self.elements_contract = elements_contract
 
     def check_contract(self, context, value, silent):
-        if not isinstance(value, collections.Set):
+        if not isinstance(value, collections.abc.Set):
             error = 'Expected a set, got %r.' % describe_type(value)
             raise ContractNotRespected(self, error, value, context)
 

--- a/src/contracts/testing/test_decorator.py
+++ b/src/contracts/testing/test_decorator.py
@@ -346,7 +346,7 @@ class DecoratorTests(unittest.TestCase):
         self.assertRaises(Exception, f2, 0, 5, 0, 6)
 
     def test_same_signature(self):
-        from inspect import getargspec
+        from inspect import getfullargspec
 
         def f(a):
             return a
@@ -355,7 +355,7 @@ class DecoratorTests(unittest.TestCase):
         def f2(a):
             return a
 
-        self.assertEqual(getargspec(f2), getargspec(f))
+        self.assertEqual(getfullargspec(f2), getfullargspec(f))
 
 
     def test_empty_types(self):


### PR DESCRIPTION
Two main updates:
* Remove use of legacy ArgSpec/getargspec API (move it to the unused Python 2 branch of the code)
* As of Python 3.10 collections Abstract Base Classes are no longer available from the collections module and have to be imported from collections.abc instead.
